### PR TITLE
refactor: use 'signalFrom' helper in services

### DIFF
--- a/src/app/auth/login/data-access/login.service.ts
+++ b/src/app/auth/login/data-access/login.service.ts
@@ -1,9 +1,9 @@
-import { Injectable, computed, inject, signal } from '@angular/core';
+import { Injectable, Signal, computed, inject } from '@angular/core';
 import { EMPTY, Subject, merge, switchMap } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { AuthService } from 'src/app/shared/data-access/auth.service';
 import { Credentials } from 'src/app/shared/interfaces/credentials';
-import { connect } from 'ngxtension/connect';
+import { signalFrom } from 'src/app/shared/signal';
 
 export type LoginStatus = 'pending' | 'authenticating' | 'success' | 'error';
 
@@ -31,12 +31,10 @@ export class LoginService {
   );
 
   // state
-  private state = signal<LoginState>({
-    status: 'pending',
-  });
+  private state: Signal<LoginState>
 
   // selectors
-  status = computed(() => this.state().status);
+  status: Signal<LoginStatus>
 
   constructor() {
     // reducers
@@ -46,6 +44,9 @@ export class LoginService {
       this.error$.pipe(map(() => ({ status: 'error' as const })))
     );
 
-    connect(this.state).with(nextState$);
+    const initialState: LoginState = { status: 'pending' };
+
+    this.state = signalFrom(initialState, nextState$);
+    this.status = computed(() => this.state().status);
   }
 }

--- a/src/app/auth/register/data-access/register.service.ts
+++ b/src/app/auth/register/data-access/register.service.ts
@@ -1,8 +1,8 @@
-import { Injectable, computed, inject, signal } from '@angular/core';
-import { connect } from 'ngxtension/connect';
+import { Injectable, Signal, computed, inject } from '@angular/core';
 import { EMPTY, Subject, catchError, map, merge, switchMap } from 'rxjs';
 import { AuthService } from 'src/app/shared/data-access/auth.service';
 import { Credentials } from 'src/app/shared/interfaces/credentials';
+import { signalFrom } from 'src/app/shared/signal';
 
 export type RegisterStatus = 'pending' | 'creating' | 'success' | 'error';
 
@@ -31,13 +31,10 @@ export class RegisterService {
   );
 
   // state
-  private state = signal<RegisterState>({
-    status: 'pending',
-    error: null,
-  });
+  private state: Signal<RegisterState>;
 
   // selectors
-  status = computed(() => this.state().status);
+  status: Signal<RegisterStatus>;
 
   constructor() {
     // reducers
@@ -47,6 +44,12 @@ export class RegisterService {
       this.error$.pipe(map(() => ({ status: 'error' as const })))
     );
 
-    connect(this.state).with(nextState$);
+    const initialState: RegisterState = {
+      status: 'pending',
+      error: null,
+    }
+
+    this.state = signalFrom(initialState, nextState$);
+    this.status = computed(() => this.state().status);
   }
 }

--- a/src/app/shared/signal.ts
+++ b/src/app/shared/signal.ts
@@ -1,0 +1,13 @@
+import { Signal, signal } from '@angular/core';
+import { connect } from 'ngxtension/connect';
+import { Observable } from 'rxjs';
+
+export function signalFrom<A>(initialState: A, updated: Observable<Partial<A>>): Signal<A>
+export function signalFrom<A>(initialState: A, updated: Observable<A>): Signal<A> {
+	const signalA = signal(initialState);
+
+	// ConnectedSignal.with expects argument of type PartialOrValue which does not work well with generic type A
+	connect(signalA).with(updated as Observable<any>);
+
+	return signalA;
+};


### PR DESCRIPTION
If you'd like to make the state signals more declarative, it can be achieved quite easily with a simple helper function (I named it `signalFrom`). This way to understand how the value of a state signal is calculated, the only place to look is its definition

The idea seems really similar to #1, where the `signalFrom` is from the rxState library.