### PR TITLE
fix init user state when user logged in

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,4 +1,9 @@
-import { ApplicationConfig, InjectionToken } from '@angular/core';
+import {
+  APP_INITIALIZER,
+  ApplicationConfig,
+  InjectionToken,
+  inject,
+} from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { initializeApp } from 'firebase/app';
 import {
@@ -12,6 +17,7 @@ import { environment } from '../environments/environment';
 
 import { routes } from './app.routes';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { AuthService } from './shared/data-access/auth.service';
 
 const app = initializeApp(environment.firebase);
 
@@ -42,6 +48,19 @@ export const FIRESTORE = new InjectionToken('Firebase firestore', {
   },
 });
 
+const initializeUserState = () => ({
+  provide: APP_INITIALIZER,
+  multi: true,
+  useFactory: () => {
+    const authService = inject(AuthService);
+    return () => authService.userStateInitialized();
+  },
+});
+
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(routes), provideAnimations()],
+  providers: [
+    provideRouter(routes),
+    provideAnimations(),
+    initializeUserState(),
+  ],
 };


### PR DESCRIPTION
this fix for issue when user logged in guard redirect user to auth/login path because of empty state after refresh page, and if you have more than two pages you never go to another route ex. you have home, auth/login and user/dashboard paths, you never get directly to user/dashboard after reload page because guard redirect you to the auth page (empty state) then auth/login redirect you to home page because auth.service got state. You need first to check if user already logged in